### PR TITLE
Add support for codim 0 and 1 external operator

### DIFF
--- a/dolfinx_external_operator/external_operator.py
+++ b/dolfinx_external_operator/external_operator.py
@@ -4,7 +4,8 @@ import numpy as np
 
 import basix
 import ufl
-from dolfinx import fem, mesh as _mesh, cpp
+from dolfinx import cpp, fem
+from dolfinx import mesh as _mesh
 from ufl.constantvalue import as_ufl
 from ufl.core.ufl_type import ufl_type
 
@@ -96,7 +97,7 @@ class FEMExternalOperator(ufl.ExternalOperator):
 
 
 def evaluate_operands(
-    external_operators: List[FEMExternalOperator], entity_maps: dict[_mesh.Mesh, np.ndarray] = None
+    external_operators: List[FEMExternalOperator], entity_maps: dict[_mesh.Mesh, np.ndarray] | None = None
 ) -> Dict[Union[ufl.core.expr.Expr, int], np.ndarray]:
     """Evaluates operands of external operators.
 
@@ -125,17 +126,27 @@ def evaluate_operands(
                 # Check if we have a sub-mesh with different codim
                 codim = operand.function_space.mesh.topology.dim - mesh.topology.dim
                 expr = fem.Expression(operand, quadrature_points)
+                # NOTE: Using expression eval might be expensive
                 if codim == 0:
-                    # TODO: Next call is potentially expensive in parallel.
-                    evaluated_operand = expr.eval(mesh, cells)
+                    if operand.function_space.mesh != mesh:
+                        inverted_map = np.empty(len(cells), dtype=np.int32)
+                        indices = np.flatnonzero(entity_maps[mesh] >= 0)
+                        inverted_map[entity_maps[mesh][indices]] = indices
+                        evaluated_operand = expr.eval(operand.function_space.mesh, inverted_map)
+                    else:
+                        evaluated_operand = expr.eval(mesh, cells)
                 elif codim == 1:
                     assert entity_maps is not None
                     # Invert entity map as it goes from parent to sub not sub to parent
                     inverted_map = np.empty(len(cells), dtype=np.int32)
-                    indices = np.flatnonzero(entity_maps[mesh]>=0)
+                    indices = np.flatnonzero(entity_maps[mesh] >= 0)
                     inverted_map[entity_maps[mesh][indices]] = indices
-                    integration_entities = cpp.fem.compute_integration_domains(fem.IntegralType.exterior_facet, operand.function_space.mesh.topology,
-                                                                               inverted_map, operand.function_space.mesh.topology.dim-1)
+                    integration_entities = cpp.fem.compute_integration_domains(
+                        fem.IntegralType.exterior_facet,
+                        operand.function_space.mesh.topology,
+                        inverted_map,
+                        operand.function_space.mesh.topology.dim - 1,
+                    )
                     evaluated_operand = expr.eval(operand.function_space.mesh, integration_entities)
                 else:
                     raise NotImplementedError("Only codim 0 and 1 are supported.")
@@ -161,7 +172,6 @@ def evaluate_external_operators(
     for external_operator in external_operators:
         ufl_operands_eval = [evaluated_operands[operand] for operand in external_operator.ufl_operands]
         external_operator_eval = external_operator.external_function(external_operator.derivatives)(*ufl_operands_eval)
-
         # NOTE: Maybe to force the user to return always a tuple?
         if type(external_operator_eval) is tuple:
             np.copyto(external_operator.ref_coefficient.x.array, external_operator_eval[0])

--- a/tests/test_codim_external_operator.py
+++ b/tests/test_codim_external_operator.py
@@ -1,0 +1,93 @@
+# Author: Jørgen S. Dokken
+# Test external operator for mixed assembly
+
+from mpi4py import MPI
+
+import numpy as np
+import pytest
+
+import basix.ufl
+import dolfinx
+import ufl
+from dolfinx_external_operator import (
+    FEMExternalOperator,
+    evaluate_external_operators,
+    evaluate_operands,
+    replace_external_operators,
+)
+
+
+def g_impl(uuh):
+    output = np.cos(uuh)  # NUMPY
+    return output.reshape(-1)  # The output must be returned flattened to one dimension
+
+
+def dgdu_impl(uuh):
+    aa = np.sin(uuh)  # NUMPY
+    return aa.reshape(-1)  # The output must be returned flattened to one dimension
+
+
+def g_external(derivatives):
+    if derivatives == (0,):  # no derivation, the function itself
+        return g_impl
+    elif derivatives == (1,):  # the derivative with respect to the operand `uh`
+        return dgdu_impl
+    else:
+        return NotImplementedError
+
+
+@pytest.mark.parametrize("quadrature_degree", range(1, 5))
+def test_external_operator_codim_1(quadrature_degree):
+    """Test assembly of codim 1 external operator"""
+
+    mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 5, 5)
+    mesh.topology.create_connectivity(mesh.topology.dim - 1, mesh.topology.dim)
+    ext_facets = dolfinx.mesh.exterior_facet_indices(mesh.topology)
+
+    V = dolfinx.fem.functionspace(mesh, ("Lagrange", 1))
+    u = dolfinx.fem.Function(V)
+    u.interpolate(lambda x: x[0] + x[1])
+
+    submesh, sub_to_parent, _, _ = dolfinx.mesh.create_submesh(mesh, mesh.topology.dim - 1, ext_facets)
+    num_entities = mesh.topology.index_map(mesh.topology.dim - 1).size_local
+    parent_to_sub = np.full(num_entities, -1, dtype=np.int32)
+    parent_to_sub[sub_to_parent] = np.arange(len(sub_to_parent), dtype=np.int32)
+    entity_maps = {submesh: parent_to_sub}
+
+    quadrature_degree = 4
+    Qe = basix.ufl.quadrature_element(submesh.basix_cell(), degree=quadrature_degree, value_shape=())
+    Q = dolfinx.fem.functionspace(submesh, Qe)
+
+    g = FEMExternalOperator(u, function_space=Q)  # g is now Symbolic not numpy involved
+    g.external_function = g_external
+
+    ft = dolfinx.mesh.meshtags(mesh, mesh.topology.dim - 1, ext_facets, np.full_like(ext_facets, 1))
+    ds = ufl.Measure(
+        "ds", domain=mesh, subdomain_data=ft, subdomain_id=1, metadata={"quadrature_degree": quadrature_degree}
+    )
+
+    for derivative in [0, 1]:
+        if derivative == 0:
+            J = g * ds
+        else:
+            J = ufl.algorithms.expand_derivatives(ufl.derivative(g, u) * ds)
+
+        J_replaced, J_external_operators = replace_external_operators(J)
+        J_compiled = dolfinx.fem.form(J_replaced, entity_maps=entity_maps)
+        # Pack coefficients for g
+        evaluated_operands = evaluate_operands(J_external_operators, entity_maps=entity_maps)
+        _ = evaluate_external_operators(J_external_operators, evaluated_operands)
+
+        Jh = dolfinx.fem.assemble_scalar(J_compiled)
+        Jh = mesh.comm.allreduce(Jh, op=MPI.SUM)
+
+        # Exact solution
+        if derivative == 0:
+            J_exact = ufl.cos(u) * ds
+        else:
+            J_exact = ufl.sin(u) * ds
+
+        J_exact_compiled = dolfinx.fem.form(J_exact)
+        J_ex = dolfinx.fem.assemble_scalar(J_exact_compiled)
+        J_ref = mesh.comm.allreduce(J_ex, op=MPI.SUM)
+        np.testing.assert_allclose(Jh, J_ref)

--- a/tests/test_codim_external_operator.py
+++ b/tests/test_codim_external_operator.py
@@ -36,6 +36,25 @@ def g_external(derivatives):
         return NotImplementedError
 
 
+def f_impl(uuh):
+    output = uuh**3  # NUMPY
+    return output.reshape(-1)  # The output must be returned flattened to one dimension
+
+
+def dfdu_impl(uuh):
+    aa = 3 * uuh**2  # NUMPY
+    return aa.reshape(-1)  # The output must be returned flattened to one dimension
+
+
+def f_external(derivatives):
+    if derivatives == (0,):  # no derivation, the function itself
+        return f_impl
+    elif derivatives == (1,):  # the derivative with respect to the operand `uh`
+        return dfdu_impl
+    else:
+        return NotImplementedError
+
+
 @pytest.mark.parametrize("quadrature_degree", range(1, 5))
 def test_external_operator_codim_1(quadrature_degree):
     """Test assembly of codim 1 external operator"""
@@ -54,7 +73,6 @@ def test_external_operator_codim_1(quadrature_degree):
     parent_to_sub[sub_to_parent] = np.arange(len(sub_to_parent), dtype=np.int32)
     entity_maps = {submesh: parent_to_sub}
 
-    quadrature_degree = 4
     Qe = basix.ufl.quadrature_element(submesh.basix_cell(), degree=quadrature_degree, value_shape=())
     Q = dolfinx.fem.functionspace(submesh, Qe)
 
@@ -86,6 +104,67 @@ def test_external_operator_codim_1(quadrature_degree):
             J_exact = ufl.cos(u) * ds
         else:
             J_exact = ufl.sin(u) * ds
+
+        J_exact_compiled = dolfinx.fem.form(J_exact)
+        J_ex = dolfinx.fem.assemble_scalar(J_exact_compiled)
+        J_ref = mesh.comm.allreduce(J_ex, op=MPI.SUM)
+        np.testing.assert_allclose(Jh, J_ref)
+
+
+@pytest.mark.parametrize("quadrature_degree", range(1, 5))
+def test_external_operator_codim_0(quadrature_degree):
+    """Test assembly of codim 1 external operator"""
+
+    mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 5, 5)
+    mesh.topology.create_connectivity(mesh.topology.dim - 1, mesh.topology.dim)
+
+    V = dolfinx.fem.functionspace(mesh, ("Lagrange", 1))
+    u = dolfinx.fem.Function(V)
+    u.interpolate(lambda x: x[0] + x[1])
+
+    def bottom(x):
+        return x[0] <= 0.2 + 1e-10
+
+    cells = dolfinx.mesh.locate_entities(mesh, mesh.topology.dim, bottom)
+    ct = dolfinx.mesh.meshtags(mesh, mesh.topology.dim, cells, np.full_like(cells, 1))
+    submesh, sub_to_parent, _, _ = dolfinx.mesh.create_submesh(mesh, mesh.topology.dim, ct.find(1))
+
+    num_entities = (
+        mesh.topology.index_map(mesh.topology.dim).size_local + mesh.topology.index_map(mesh.topology.dim).num_ghosts
+    )
+    parent_to_sub = np.full(num_entities, -1, dtype=np.int32)
+    parent_to_sub[sub_to_parent] = np.arange(len(sub_to_parent), dtype=np.int32)
+    entity_maps = {submesh: parent_to_sub}
+    Qe = basix.ufl.quadrature_element(submesh.basix_cell(), degree=quadrature_degree, value_shape=())
+    Q = dolfinx.fem.functionspace(submesh, Qe)
+
+    f = FEMExternalOperator(u, function_space=Q)  # g is now Symbolic not numpy involved
+    f.external_function = f_external
+
+    dx = ufl.Measure(
+        "dx", domain=mesh, subdomain_data=ct, subdomain_id=1, metadata={"quadrature_degree": quadrature_degree}
+    )
+
+    for derivative in [0, 1]:
+        if derivative == 0:
+            J = f * dx
+        else:
+            J = ufl.algorithms.expand_derivatives(ufl.derivative(f, u) * dx)
+
+        J_replaced, J_external_operators = replace_external_operators(J)
+        J_compiled = dolfinx.fem.form(J_replaced, entity_maps=entity_maps)
+        # Pack coefficients for g
+        evaluated_operands = evaluate_operands(J_external_operators, entity_maps=entity_maps)
+        _ = evaluate_external_operators(J_external_operators, evaluated_operands)
+
+        Jh = dolfinx.fem.assemble_scalar(J_compiled)
+        Jh = mesh.comm.allreduce(Jh, op=MPI.SUM)
+
+        # Exact solution
+        if derivative == 0:
+            J_exact = u**3 * dx
+        else:
+            J_exact = 3 * u**2 * dx
 
         J_exact_compiled = dolfinx.fem.form(J_exact)
         J_ex = dolfinx.fem.assemble_scalar(J_exact_compiled)


### PR DESCRIPTION
Add support for having external operators on boundary (as was tried in): https://fenicsproject.discourse.group/t/newton-and-script-dependant-neumann-boundary-condition/14882/17
Adding the appropriate support for quadrature spaces on (exterior) facets, such that we can have an external operator living on the boundary only.

Also add support for mixed assembly of codim-0 (i.e. the external operator lives on a subset of the original domain).