### PR TITLE
Add extraction of ufl domain from operands

### DIFF
--- a/tests/test_codim_external_operator.py
+++ b/tests/test_codim_external_operator.py
@@ -38,7 +38,7 @@ def g_external(derivatives):
 
 def f_impl(uuh_square):
     output = uuh_square * np.sqrt(uuh_square)  # NUMPY
-    return output.reshape(-1)  # The output must be 
+    return output.reshape(-1)  # The output must be returned flattened to one dimension
 
 def dfdu_impl(uuh_square):
     aa = 3 * uuh_square  # NUMPY

--- a/tests/test_codim_external_operator.py
+++ b/tests/test_codim_external_operator.py
@@ -36,13 +36,12 @@ def g_external(derivatives):
         return NotImplementedError
 
 
-def f_impl(uuh):
-    output = uuh**3  # NUMPY
-    return output.reshape(-1)  # The output must be returned flattened to one dimension
+def f_impl(uuh_square):
+    output = uuh_square * np.sqrt(uuh_square)  # NUMPY
+    return output.reshape(-1)  # The output must be 
 
-
-def dfdu_impl(uuh):
-    aa = 3 * uuh**2  # NUMPY
+def dfdu_impl(uuh_square):
+    aa = 3 * uuh_square  # NUMPY
     return aa.reshape(-1)  # The output must be returned flattened to one dimension
 
 
@@ -76,8 +75,7 @@ def test_external_operator_codim_1(quadrature_degree):
     Qe = basix.ufl.quadrature_element(submesh.basix_cell(), degree=quadrature_degree, value_shape=())
     Q = dolfinx.fem.functionspace(submesh, Qe)
 
-    g = FEMExternalOperator(u, function_space=Q)  # g is now Symbolic not numpy involved
-    g.external_function = g_external
+    g = FEMExternalOperator(u, function_space=Q, external_function=g_external) # g is now Symbolic not numpy involved
 
     ft = dolfinx.mesh.meshtags(mesh, mesh.topology.dim - 1, ext_facets, np.full_like(ext_facets, 1))
     ds = ufl.Measure(
@@ -113,8 +111,7 @@ def test_external_operator_codim_1(quadrature_degree):
 
 @pytest.mark.parametrize("quadrature_degree", range(1, 5))
 def test_external_operator_codim_0(quadrature_degree):
-    """Test assembly of codim 1 external operator"""
-
+    """Test assembly of codim 0 external operator"""
     mesh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, 5, 5)
     mesh.topology.create_connectivity(mesh.topology.dim - 1, mesh.topology.dim)
 
@@ -138,8 +135,7 @@ def test_external_operator_codim_0(quadrature_degree):
     Qe = basix.ufl.quadrature_element(submesh.basix_cell(), degree=quadrature_degree, value_shape=())
     Q = dolfinx.fem.functionspace(submesh, Qe)
 
-    f = FEMExternalOperator(u, function_space=Q)  # g is now Symbolic not numpy involved
-    f.external_function = f_external
+    f = FEMExternalOperator(u*u, function_space=Q, external_function=f_external) # g is now Symbolic not numpy involved
 
     dx = ufl.Measure(
         "dx", domain=mesh, subdomain_data=ct, subdomain_id=1, metadata={"quadrature_degree": quadrature_degree}
@@ -152,11 +148,11 @@ def test_external_operator_codim_0(quadrature_degree):
             J = ufl.algorithms.expand_derivatives(ufl.derivative(f, u) * dx)
 
         J_replaced, J_external_operators = replace_external_operators(J)
-        J_compiled = dolfinx.fem.form(J_replaced, entity_maps=entity_maps)
         # Pack coefficients for g
         evaluated_operands = evaluate_operands(J_external_operators, entity_maps=entity_maps)
         _ = evaluate_external_operators(J_external_operators, evaluated_operands)
 
+        J_compiled = dolfinx.fem.form(J_replaced, entity_maps=entity_maps)
         Jh = dolfinx.fem.assemble_scalar(J_compiled)
         Jh = mesh.comm.allreduce(Jh, op=MPI.SUM)
 


### PR DESCRIPTION
@a-latyshev  I've modifed the codim support such that it extracts the ufl domain from the operand, and passes that on to the expression eval, avoiding an extra input argument.