### PR TITLE
Fix sign of Newton update

### DIFF
--- a/doc/demo/demo_plasticity_von_mises.py
+++ b/doc/demo/demo_plasticity_von_mises.py
@@ -478,7 +478,7 @@ for i, loading_v in enumerate(loadings):
         external_operator_problem.solve(du)
         du.x.scatter_forward()
 
-        Du.x.petsc_vec.axpy(-1.0, du.x.petsc_vec)
+        Du.x.petsc_vec.axpy(1.0, du.x.petsc_vec)
         Du.x.scatter_forward()
 
         evaluated_operands = evaluate_operands(F_external_operators)


### PR DESCRIPTION
My mistake - I probably switched the sign of the residual.

This will be groundwork for experimenting with porting this to the built-in
Newton solver (and possibly making patches necessary in DOLFINx).
