### PR TITLE
Expand high-level operands in external operators

### DIFF
--- a/src/dolfinx_external_operator/external_operator.py
+++ b/src/dolfinx_external_operator/external_operator.py
@@ -57,12 +57,10 @@ class FEMExternalOperator(ufl.ExternalOperator):
             raise TypeError("FEMExternalOperator currently only supports Quadrature elements.")
 
         self.ufl_operands = tuple(map(expand_derivatives, map(as_ufl, operands)))  # expend high-level operands
-        for operand in self.ufl_operands:
-            if isinstance(operand, FEMExternalOperator):
-                raise TypeError("Use of FEMExternalOperators as operands is not implemented.")
 
         if coefficient is not None and coefficient.function_space != function_space:
             raise TypeError("The provided coefficient must be defined on the same function space as the operator.")
+            
         super().__init__(
             *self.ufl_operands,
             function_space=function_space,

--- a/src/dolfinx_external_operator/external_operator.py
+++ b/src/dolfinx_external_operator/external_operator.py
@@ -60,7 +60,7 @@ class FEMExternalOperator(ufl.ExternalOperator):
 
         if coefficient is not None and coefficient.function_space != function_space:
             raise TypeError("The provided coefficient must be defined on the same function space as the operator.")
-            
+
         super().__init__(
             *self.ufl_operands,
             function_space=function_space,

--- a/src/dolfinx_external_operator/external_operator.py
+++ b/src/dolfinx_external_operator/external_operator.py
@@ -6,7 +6,7 @@ from dolfinx import fem
 from dolfinx import mesh as _mesh
 from ufl.constantvalue import as_ufl
 from ufl.core.ufl_type import ufl_type
-from ufl.algorithms.apply_algebra_lowering import apply_algebra_lowering
+from ufl.algorithms import expand_derivatives
 
 @ufl_type(num_ops="varying", is_differential=True, use_default_hash=False)
 class FEMExternalOperator(ufl.ExternalOperator):
@@ -49,7 +49,7 @@ class FEMExternalOperator(ufl.ExternalOperator):
         if ufl_element.family_name != "quadrature":
             raise TypeError("FEMExternalOperator currently only supports Quadrature elements.")
 
-        self.ufl_operands = tuple(map(apply_algebra_lowering, map(as_ufl, operands)))
+        self.ufl_operands = tuple(map(expand_derivatives, map(as_ufl, operands))) # expend high-level operands
         for operand in self.ufl_operands:
             if isinstance(operand, FEMExternalOperator):
                 raise TypeError("Use of FEMExternalOperators as operands is not implemented.")

--- a/src/dolfinx_external_operator/external_operator.py
+++ b/src/dolfinx_external_operator/external_operator.py
@@ -50,7 +50,7 @@ class FEMExternalOperator(ufl.ExternalOperator):
         if ufl_element.family_name != "quadrature":
             raise TypeError("FEMExternalOperator currently only supports Quadrature elements.")
 
-        self.ufl_operands = tuple(map(expand_derivatives, map(as_ufl, operands))) # expend high-level operands
+        self.ufl_operands = tuple(map(expand_derivatives, map(as_ufl, operands)))  # expend high-level operands
         for operand in self.ufl_operands:
             if isinstance(operand, FEMExternalOperator):
                 raise TypeError("Use of FEMExternalOperators as operands is not implemented.")

--- a/src/dolfinx_external_operator/external_operator.py
+++ b/src/dolfinx_external_operator/external_operator.py
@@ -4,9 +4,10 @@ import basix
 import ufl
 from dolfinx import fem
 from dolfinx import mesh as _mesh
+from ufl.algorithms import expand_derivatives
 from ufl.constantvalue import as_ufl
 from ufl.core.ufl_type import ufl_type
-from ufl.algorithms import expand_derivatives
+
 
 @ufl_type(num_ops="varying", is_differential=True, use_default_hash=False)
 class FEMExternalOperator(ufl.ExternalOperator):

--- a/src/dolfinx_external_operator/external_operator.py
+++ b/src/dolfinx_external_operator/external_operator.py
@@ -6,7 +6,7 @@ from dolfinx import fem
 from dolfinx import mesh as _mesh
 from ufl.constantvalue import as_ufl
 from ufl.core.ufl_type import ufl_type
-
+from ufl.algorithms.apply_algebra_lowering import apply_algebra_lowering
 
 @ufl_type(num_ops="varying", is_differential=True, use_default_hash=False)
 class FEMExternalOperator(ufl.ExternalOperator):
@@ -49,7 +49,7 @@ class FEMExternalOperator(ufl.ExternalOperator):
         if ufl_element.family_name != "quadrature":
             raise TypeError("FEMExternalOperator currently only supports Quadrature elements.")
 
-        self.ufl_operands = tuple(map(as_ufl, operands))
+        self.ufl_operands = tuple(map(apply_algebra_lowering, map(as_ufl, operands)))
         for operand in self.ufl_operands:
             if isinstance(operand, FEMExternalOperator):
                 raise TypeError("Use of FEMExternalOperators as operands is not implemented.")
@@ -58,7 +58,7 @@ class FEMExternalOperator(ufl.ExternalOperator):
             raise TypeError("The provided coefficient must be defined on the same function space as the operator.")
 
         super().__init__(
-            *operands,
+            *self.ufl_operands,
             function_space=function_space,
             derivatives=derivatives,
             argument_slots=argument_slots,

--- a/test/test_external_operators.py
+++ b/test/test_external_operators.py
@@ -139,6 +139,7 @@ def test_replacement_mechanism():
     check_replacement(FN4, [N1, N2], operators_count_after_AD=4)
     check_replacement(Fn5 + Fn1, [n1, n2], operators_count_after_AD=4)
 
+
 def check_operand_expansion(operand: ufl.core.expr.Expr, u: fem.Function):
     domain = u.function_space.mesh
     V = u.function_space
@@ -154,6 +155,7 @@ def check_operand_expansion(operand: ufl.core.expr.Expr, u: fem.Function):
     assert renumber_indices(N.ufl_operands[0]) == operand_expanded
     dN = J_external_operators[0]
     assert renumber_indices(dN.ufl_operands[0]) == operand_expanded
+
 
 def test_indexed_operands():
     domain = create_unit_square(MPI.COMM_WORLD, 2, 2)


### PR DESCRIPTION
Expands high-level compound operands to equivalent representations using basic operands. Expansion is done preventively in the external operator constructor to match with operands after AD.