### PR TITLE
Get red of ufl.algorithms.expand_derivatives

### DIFF
--- a/doc/demo/demo_hyperelasticity.py
+++ b/doc/demo/demo_hyperelasticity.py
@@ -526,10 +526,9 @@ dx = ufl.Measure("dx", domain=domain, metadata=metadata)
 u_hat = ufl.TrialFunction(V)
 F = ufl.inner(ufl.grad(v), P) * dx
 J = ufl.derivative(F, u, u_hat)
-J_expanded = ufl.algorithms.expand_derivatives(J)
 
 F_replaced, F_external_operators = replace_external_operators(F)
-J_replaced, J_external_operators = replace_external_operators(J_expanded)
+J_replaced, J_external_operators = replace_external_operators(J)
 
 F_form = fem.form(F_replaced)
 J_form = fem.form(J_replaced)

--- a/doc/demo/demo_nonlinear_heat_equation_part1.py
+++ b/doc/demo/demo_nonlinear_heat_equation_part1.py
@@ -369,6 +369,12 @@ J_replaced, J_external_operators = replace_external_operators(J_expanded)
 # `F` and `J_expanded`.
 # ```
 #
+# ```{note}
+# Starting from `v0.10.1`, the call of `ufl.algorithms.expand_derivatives(J)` is
+# not required anymore since the derivative is expanded in
+# `replace_external_operators`.
+# ```
+#
 # ### Assembly
 # We can now proceed with the finite element assembly in three key steps.
 # 1. Evaluate the operands (`T` and `sigma`) associated with the

--- a/doc/demo/demo_nonlinear_heat_equation_part1.py
+++ b/doc/demo/demo_nonlinear_heat_equation_part1.py
@@ -370,7 +370,7 @@ J_replaced, J_external_operators = replace_external_operators(J_expanded)
 # ```
 #
 # ```{note}
-# Starting from `v0.10.1`, the call of `ufl.algorithms.expand_derivatives(J)` is
+# Starting from `v0.10.1`, the call to `ufl.algorithms.expand_derivatives(J)` is
 # not required anymore since the derivative is expanded in
 # `replace_external_operators`.
 # ```

--- a/doc/demo/demo_nonlinear_heat_equation_part2.py
+++ b/doc/demo/demo_nonlinear_heat_equation_part2.py
@@ -300,9 +300,8 @@ q_.external_function = q_external
 # %%
 T_hat = TrialFunction(V)
 J = derivative(F, T, T_hat)
-J_expanded = ufl.algorithms.expand_derivatives(J)
 F_replaced, F_external_operators = replace_external_operators(F)
-J_replaced, J_external_operators = replace_external_operators(J_expanded)
+J_replaced, J_external_operators = replace_external_operators(J)
 evaluated_operands = evaluate_operands(F_external_operators)
 _ = evaluate_external_operators(F_external_operators, evaluated_operands)
 

--- a/doc/demo/demo_plasticity_mohr_coulomb.py
+++ b/doc/demo/demo_plasticity_mohr_coulomb.py
@@ -624,10 +624,9 @@ def F_ext(v):
 u_hat = ufl.TrialFunction(V)
 F = ufl.inner(epsilon(v), sigma) * dx - F_ext(v)
 J = ufl.derivative(F, Du, u_hat)
-J_expanded = ufl.algorithms.expand_derivatives(J)
 
 F_replaced, F_external_operators = replace_external_operators(F)
-J_replaced, J_external_operators = replace_external_operators(J_expanded)
+J_replaced, J_external_operators = replace_external_operators(J)
 
 F_form = fem.form(F_replaced)
 J_form = fem.form(J_replaced)

--- a/doc/demo/demo_plasticity_von_mises.py
+++ b/doc/demo/demo_plasticity_von_mises.py
@@ -388,10 +388,9 @@ sigma.external_function = sigma_external
 # %%
 u_hat = ufl.TrialFunction(V)
 J = ufl.derivative(F, Du, u_hat)
-J_expanded = ufl.algorithms.expand_derivatives(J)
 
 F_replaced, F_external_operators = replace_external_operators(F)
-J_replaced, J_external_operators = replace_external_operators(J_expanded)
+J_replaced, J_external_operators = replace_external_operators(J)
 
 F_form = fem.form(F_replaced)
 J_form = fem.form(J_replaced)

--- a/doc/demo/demo_simple_example.py
+++ b/doc/demo/demo_simple_example.py
@@ -20,9 +20,9 @@
 # the `ref_coefficient` attribute of the `femExternalOperator` object.
 #
 # Once a form containing the external operator is defined it can be
-# successfully differentiated using the UFL function `expand_derivatives`. The
-# latter recursively applies the automatic differentiation (AD) feature of UFL
-# to the form and calculates the Gateau derivative $\frac{d N}{d u}$ of the
+# successfully differentiated. UFL recursively applies the automatic
+# differentiation (AD) feature of UFL to the form and calculates the
+# Gateau derivative $\frac{d N}{d u}$ of the
 # external operator according to the chain rule. During this procedure, the
 # algorithm creates a new `femExternalOperator` object representing the
 # derivative $\frac{d N}{d u}$. It preserves an appropriate local shape of the
@@ -188,8 +188,7 @@ F_replaced, F_ex_ops_list = replace_external_operators(F)
 F_dolfinx = fem.form(F_replaced)
 
 # %%
-J_expanded = ufl.algorithms.expand_derivatives(J)
-J_replaced, J_ex_ops_list = replace_external_operators(J_expanded)
+J_replaced, J_ex_ops_list = replace_external_operators(J)
 J_dolfinx = fem.form(J_replaced)
 
 # %% [markdown]
@@ -198,8 +197,8 @@ J_dolfinx = fem.form(J_replaced)
 # objects and finite objects `fem.Function`, the user must be aware that once
 # the expansion of the derivatives is performed, the framework creates new
 # functional spaces for shapes of derivatives of external operators and
-# allocates memory for the appropriate coefficients. Thus, `expand_derivatives`
-# may lead to "hidden" memory allocations, which may not be exptected by UFL
+# allocates memory for the appropriate coefficients. Thus, this expansion
+# may lead to "hidden" memory allocations, which may not be expected by UFL
 # users.
 # ```
 #


### PR DESCRIPTION
Starting from v0.10.1, the call to `ufl.algorithms.expand_derivatives(J)` is not required anymore since the derivative is expanded in `replace_external_operators`.