### PR TITLE
Prepare for v0.11.0 and optimize real space evaluation

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
-    container: ghcr.io/fenics/dolfinx/lab:v0.10.0
+    container: ghcr.io/fenics/dolfinx/lab:v0.11.0
     
     env:
       PYVISTA_OFF_SCREEN: true

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   dist:
     runs-on: ubuntu-latest
-    container: ghcr.io/fenics/dolfinx/dolfinx:v0.10.0
+    container: ghcr.io/fenics/dolfinx/dolfinx:v0.11.0
     env:
       DEB_PYTHON_INSTALL_LAYOUT: deb_system
 

--- a/doc/demo/06_demo_hyperelasticity.py
+++ b/doc/demo/06_demo_hyperelasticity.py
@@ -9,7 +9,7 @@
 #       format_version: '1.3'
 #       jupytext_version: 1.19.3
 #   kernelspec:
-#     display_name: fenicsx-0.10.0
+#     display_name: fenicsx-0.11.0
 #     language: python
 #     name: python3
 # ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0.0", "pip>=23.1"]
 
 [project]
 name = "dolfinx-external-operator"
-version = "0.10.2"
+version = "0.11.0"
 description = "An implementation of ufl.ExternalOperator for DOLFINx"
 authors = [
     { name = "Andrey Latyshev", email = "andrey.latyshev@uni.lu" },
@@ -12,8 +12,8 @@ authors = [
 license = { file = "LICENSE" }
 readme = "README.md"
 dependencies = [
-    "fenics-dolfinx>=0.10.0,<0.11.0",
-    "fenics-ufl>=2025.2.0,<2026.2.0",
+    "fenics-dolfinx>=0.11.0,<0.12.0",
+    "fenics-ufl>=2026.1.0",
 ]
 
 [project.scripts]

--- a/src/dolfinx_external_operator/external_operator.py
+++ b/src/dolfinx_external_operator/external_operator.py
@@ -427,7 +427,8 @@ def evaluate_operands(
                         evaluated_operand_at_entity,
                         shape=(len(entities), external_operator.eval_points.shape[0], c_size),  # type: ignore
                         strides=(0, 0, evaluated_operand_at_entity.itemsize),
-                    writeable=False)
+                        writeable=False,
+                    )
                 else:
                     evaluated_operand = expr.eval(operand_mesh, entities)
                 evaluated_operands[key] = evaluated_operand

--- a/src/dolfinx_external_operator/external_operator.py
+++ b/src/dolfinx_external_operator/external_operator.py
@@ -413,6 +413,22 @@ def evaluate_operands(
                         external_operator._compiled_operands[operand] = cached
 
                     expr, operand_mesh = cached
+                if isinstance(operand, fem.Function) and operand.ufl_element().is_real:
+                    # Optimize tabulation for real spaces by avoiding unnecessary memory allocation
+                    if entities.ndim == 1:
+                        entity = entities[:1]
+                    elif entities.ndim == 2:
+                        entity = entities[:1, :]
+                    else:
+                        raise ValueError("Entities array has too many dimensions.")
+                    evaluated_operand_at_entity = expr.eval(operand_mesh, entity)
+                    c_size = evaluated_operand_at_entity.shape[-1]
+                    evaluated_operand = np.lib.stride_tricks.as_strided(
+                        evaluated_operand_at_entity,
+                        shape=(len(entities), external_operator.eval_points.shape[0], c_size),  # type: ignore
+                        strides=(0, 0, evaluated_operand_at_entity.itemsize),
+                    writeable=False)
+                else:
                     evaluated_operand = expr.eval(operand_mesh, entities)
                 evaluated_operands[key] = evaluated_operand
     return evaluated_operands

--- a/src/dolfinx_external_operator/external_operator.py
+++ b/src/dolfinx_external_operator/external_operator.py
@@ -413,24 +413,25 @@ def evaluate_operands(
                         external_operator._compiled_operands[operand] = cached
 
                     expr, operand_mesh = cached
-                if isinstance(operand, fem.Function) and operand.ufl_element().is_real:
-                    # Optimize tabulation for real spaces by avoiding unnecessary memory allocation
-                    if entities.ndim == 1:
-                        entity = entities[:1]
-                    elif entities.ndim == 2:
-                        entity = entities[:1, :]
+                    if isinstance(operand, fem.Function) and operand.ufl_element().is_real:
+                        # Optimize tabulation for real spaces by avoiding unnecessary memory allocation
+                        if entities.ndim == 1:
+                            entity = entities[:1]
+                        elif entities.ndim == 2:
+                            entity = entities[:1, :]
+                        else:
+                            raise ValueError("Entities array has too many dimensions.")
+                        evaluated_operand_at_entity = expr.eval(operand_mesh, entity)
+                        c_size = evaluated_operand_at_entity.shape[-1]
+                        evaluated_operand = np.lib.stride_tricks.as_strided(
+                            evaluated_operand_at_entity,
+                            shape=(len(entities), external_operator.eval_points.shape[0], c_size),  # type: ignore
+                            strides=(0, 0, evaluated_operand_at_entity.itemsize),
+                            writeable=False,
+                        )
                     else:
-                        raise ValueError("Entities array has too many dimensions.")
-                    evaluated_operand_at_entity = expr.eval(operand_mesh, entity)
-                    c_size = evaluated_operand_at_entity.shape[-1]
-                    evaluated_operand = np.lib.stride_tricks.as_strided(
-                        evaluated_operand_at_entity,
-                        shape=(len(entities), external_operator.eval_points.shape[0], c_size),  # type: ignore
-                        strides=(0, 0, evaluated_operand_at_entity.itemsize),
-                        writeable=False,
-                    )
-                else:
-                    evaluated_operand = expr.eval(operand_mesh, entities)
+                        evaluated_operand = expr.eval(operand_mesh, entities)
+
                 evaluated_operands[key] = evaluated_operand
     return evaluated_operands
 


### PR DESCRIPTION
Uses the trick I made in https://github.com/scientificcomputing/fenicsx-jax/blob/main/src/fenicsx_jax/fem.py#L123-L141
to optimize tabulation and memory for external operands that depend on real spaces (only tabulate on first entry and then view into same memory, no copy per entity)