### PR TITLE
Propagate custom quadrature scheme during differentiation

### DIFF
--- a/src/dolfinx_external_operator/external_operator.py
+++ b/src/dolfinx_external_operator/external_operator.py
@@ -33,6 +33,7 @@ def new_element_from_new_shape(element: _ElementBase, diff_shape: tuple[int, ...
         pts, wts = element.custom_quadrature()
         element = basix.ufl.quadrature_element(
             mesh.topology.cell_name(),
+            degree=element.degree,
             points=pts,
             weights=wts,
             value_shape=new_shape,

--- a/src/dolfinx_external_operator/external_operator.py
+++ b/src/dolfinx_external_operator/external_operator.py
@@ -30,9 +30,11 @@ def new_element_from_new_shape(element: _ElementBase, diff_shape: tuple[int, ...
     new_shape = element.reference_value_shape + diff_shape
 
     if element.element_family is None:
+        pts, wts = element.custom_quadrature()
         element = basix.ufl.quadrature_element(
             mesh.topology.cell_name(),
-            degree=element.degree,
+            points=pts,
+            weights=wts,
             value_shape=new_shape,
         )
     else:

--- a/test/test_external_operators_construction.py
+++ b/test/test_external_operators_construction.py
@@ -204,6 +204,7 @@ def test_no_operator():
     assert data == {}
     evaluate_external_operators(external_operators, data)
 
+
 def test_scheme_after_differentiation():
     """Tests that new_element_from_new_shape propagates custom quadrature schemes to derivative spaces."""
     from dolfinx.mesh import CellType

--- a/test/test_external_operators_construction.py
+++ b/test/test_external_operators_construction.py
@@ -3,10 +3,11 @@
 
 from mpi4py import MPI
 
+import pytest
 import basix
 import ufl
 from dolfinx import fem
-from dolfinx.mesh import create_unit_square
+from dolfinx.mesh import create_unit_square, create_unit_cube, CellType
 from dolfinx_external_operator import (
     FEMExternalOperator,
     evaluate_external_operators,
@@ -205,15 +206,33 @@ def test_no_operator():
     evaluate_external_operators(external_operators, data)
 
 
-def test_scheme_after_differentiation():
+@pytest.mark.parametrize(
+    "cell_type, scheme",
+    [
+        (CellType.triangle, "default"),
+        (CellType.quadrilateral, "default"),
+        (CellType.tetrahedron, "default"),
+        (CellType.hexahedron, "default"),
+        (CellType.triangle, "gauss_jacobi"),
+        (CellType.quadrilateral, "gauss_jacobi"),
+        (CellType.tetrahedron, "gauss_jacobi"),
+        (CellType.hexahedron, "gauss_jacobi"),
+        (CellType.quadrilateral, "GLL"),
+        (CellType.hexahedron, "GLL"),
+        (CellType.triangle, "xiao_gimbutas"),
+        (CellType.tetrahedron, "xiao_gimbutas"),
+    ],
+)
+def test_scheme_after_differentiation(cell_type, scheme):
     """Tests that new_element_from_new_shape propagates custom quadrature schemes to derivative spaces."""
-    from dolfinx.mesh import CellType
     from dolfinx_external_operator.external_operator import new_element_from_new_shape
 
-    # Use CellType.quadrilateral to support the GLL scheme
-    domain = create_unit_square(MPI.COMM_WORLD, 1, 1, cell_type=CellType.quadrilateral)
+    if cell_type in [CellType.tetrahedron, CellType.hexahedron]:
+        domain = create_unit_cube(MPI.COMM_WORLD, 1, 1, 1, cell_type=cell_type)
+    else:
+        domain = create_unit_square(MPI.COMM_WORLD, 1, 1, cell_type=cell_type)
 
-    orig_el = basix.ufl.quadrature_element(domain.topology.cell_name(), degree=1, scheme="GLL")
+    orig_el = basix.ufl.quadrature_element(domain.topology.cell_name(), degree=2, scheme=scheme)
 
     diff_shape = (1,)
     new_el = new_element_from_new_shape(orig_el, diff_shape, domain)

--- a/test/test_external_operators_construction.py
+++ b/test/test_external_operators_construction.py
@@ -4,10 +4,11 @@
 from mpi4py import MPI
 
 import pytest
+
 import basix
 import ufl
 from dolfinx import fem
-from dolfinx.mesh import create_unit_square, create_unit_cube, CellType
+from dolfinx.mesh import CellType, create_unit_cube, create_unit_square
 from dolfinx_external_operator import (
     FEMExternalOperator,
     evaluate_external_operators,

--- a/test/test_external_operators_construction.py
+++ b/test/test_external_operators_construction.py
@@ -203,3 +203,24 @@ def test_no_operator():
     data = evaluate_operands(external_operators)
     assert data == {}
     evaluate_external_operators(external_operators, data)
+
+def test_scheme_after_differentiation():
+    """Tests that new_element_from_new_shape propagates custom quadrature schemes to derivative spaces."""
+    from dolfinx.mesh import CellType
+    from dolfinx_external_operator.external_operator import new_element_from_new_shape
+
+    # Use CellType.quadrilateral to support the GLL scheme
+    domain = create_unit_square(MPI.COMM_WORLD, 1, 1, cell_type=CellType.quadrilateral)
+
+    orig_el = basix.ufl.quadrature_element(domain.topology.cell_name(), degree=1, scheme="GLL")
+
+    diff_shape = (1,)
+    new_el = new_element_from_new_shape(orig_el, diff_shape, domain)
+
+    Q_orig = fem.functionspace(domain, orig_el)
+    Q_deriv = fem.functionspace(domain, new_el)
+
+    pts_orig = sorted(Q_orig.element.interpolation_points.tolist())
+    pts_deriv = sorted(Q_deriv.element.interpolation_points.tolist())
+
+    assert pts_orig == pts_deriv


### PR DESCRIPTION
This PR fixes a silent bug that degrades Newton convergence by causing a quadrature mismatch between residuals and Jacobians. Previously, new_element_from_new_shape reconstructed quadrature spaces using only the element degree, forcing custom schemes to fall back to standard Gauss-Legendre.

To resolve this, I modified the element_family is None check to explicitly capture and transfer .custom_quadrature() rules, and added a regression test to ensure GLL points are preserved during differentiation.